### PR TITLE
Blink1 Client Notifications Plugin

### DIFF
--- a/client/blink1.py
+++ b/client/blink1.py
@@ -2,6 +2,8 @@ import king_phisher.client.gui_utilities as gui_utilities
 import king_phisher.client.plugins as plugins
 import king_phisher.client.server_events as server_events
 
+from gi.repository import GLib
+
 try:
 	from blink1 import blink1
 	import usb.core
@@ -40,6 +42,7 @@ class Plugin(plugins.ClientPlugin):
 				'Unable to find the Blink(1) device.'
 			)
 			return False
+		self._gsrc_id = None
 		if self.application.server_events is None:
 			self.signal_connect('server-connected', lambda app: self._connect_server_events())
 		else:
@@ -52,12 +55,21 @@ class Plugin(plugins.ClientPlugin):
 		self._blink1 = None
 
 	def _blink1_set_color(self, color):
-		self._blink1.fade_to_color(250, color)
+		self._blink1.fade_to_color(375, color)
+		if color != 'black':
+			if self._gsrc_id is not None:
+				GLib.source_remove(self._gsrc_id)
+			self._gsrc_id = GLib.timeout_add(1625, self._blink1_off)
 		self._color = color
 
 	def _blink1_off(self):
 		self._blink1_set_color('black')
 		self._color = None
+
+	def _blink1_off_timeout(self):
+		self._gsrc_id = None
+		self._blink1_off()
+		return False
 
 	def _connect_server_events(self):
 		self.signal_connect_server_event(

--- a/client/blink1.py
+++ b/client/blink1.py
@@ -111,7 +111,7 @@ class Plugin(plugins.ClientPlugin):
 		)
 		return True
 
-	def _signal_db(self, color):
+	def _signal_db(self, color, rows):
 		if self.config['filter_campaigns']:
 			if all(str(row.campaign_id) != self.application.config['campaign_id'] for row in rows):
 				return
@@ -119,8 +119,8 @@ class Plugin(plugins.ClientPlugin):
 
 	@server_events.event_type_filter('inserted', is_method=True)
 	def signal_db_credentials(self, _, event_type, rows):
-		self._signal_db(self.config['color_credentials'])
+		self._signal_db(self.config['color_credentials'], rows)
 
 	@server_events.event_type_filter('inserted', is_method=True)
-	def signal_db_visits(self, _, event_type, row):
-		self._signal_db(self.config['color_visits'])
+	def signal_db_visits(self, _, event_type, rows):
+		self._signal_db(self.config['color_visits'], rows)

--- a/client/blink1.py
+++ b/client/blink1.py
@@ -80,7 +80,11 @@ class Plugin(plugins.ClientPlugin):
 		self._blink1 = None
 
 	def _blink1_set_color(self, color):
-		self._blink1.fade_to_color(375, color)
+		try:
+			self._blink1.fade_to_color(375, color)
+		except usb.core.USBError as error:
+			self.logger.warning("encountered a USB error '{0}' while setting the color of the blink(1)".format(error.strerror))
+			return
 		if color != 'black':
 			if self._gsrc_id is not None:
 				GLib.source_remove(self._gsrc_id)

--- a/client/blink1.py
+++ b/client/blink1.py
@@ -44,10 +44,10 @@ class Plugin(plugins.ClientPlugin):
 		)
 		return True
 
-	@server_events.filter_event_type('inserted')
+	@server_events.event_type_filter('inserted')
 	def signal_db_credentials(self, _, event_type, objects):
 		self._blink1.fade_to_color(0, 'blue')
 
-	@server_events.filter_event_type('inserted')
+	@server_events.event_type_filter('inserted')
 	def signal_db_visits(self, _, event_type, objects):
 		self._blink1.fade_to_color(0, 'cyan')

--- a/client/blink1.py
+++ b/client/blink1.py
@@ -1,0 +1,53 @@
+import king_phisher.client.gui_utilities as gui_utilities
+import king_phisher.client.plugins as plugins
+import king_phisher.client.server_events as server_events
+
+try:
+	from blink1 import blink1
+except ImportError:
+	has_blink1 = False
+else:
+	has_blink1 = True
+
+class Plugin(plugins.ClientPlugin):
+	authors = ['Spencer McIntyre']
+	title = 'Blink(1) Notifications'
+	description = """
+	A plugin which will flash a Blink(1) peripheral based on campaign events.
+	"""
+	homepage = 'https://github.com/securestate/king-phisher-plugins'
+	req_min_version = '1.6.0b0'
+	req_packages = {
+		'blink1': has_blink1
+	}
+	def initialize(self):
+		try:
+			self._blink1 = blink1.Blink1()
+		except blink1.BlinkConnectionFailed:
+			gui_utilities.show_dialog_error(
+				'Connection Error',
+				self.application.get_active_window(),
+				'Unable to connect to the Blink(1) device.'
+			)
+			return False
+		self.signal_connect_server_event(
+			'db-credentials',
+			self.signal_db_credentials
+			('inserted',),
+			('id', 'campaign_id')
+		)
+		self.signal_connect_server_event(
+			'db-visits',
+			self.signal_db_vists,
+			('inserted',),
+			('id', 'campaign_id')
+		)
+		return True
+
+	@server_events.filter_event_type('inserted')
+	def signal_db_credentials(self, _, event_type, objects):
+		self._blink1.fade_to_color(0, 'blue')
+
+	@server_events.filter_event_type('inserted')
+	def signal_db_visits(self, _, event_type, objects):
+		self._blink1.fade_to_color(0, 'cyan')


### PR DESCRIPTION
This PR adds a Blink(1) client plugin for flashing campaign notifications. I've tested it with the mk2 model but it should be compatible with the original hardware as well.

To do:
- [x] Read the plugin information and configuration options to ensure they make sense
- [x] Load and enable the plugin
- [x] Run a campaign and see blinky lights

**Note: This requires the new server-event publishing logic that is currently only in the King Phisher `dev` branch, ie 1.6.0-dev. This plugin will correctly be marked as incompatible with versions of the King Phisher client prior to 1.6.0 beta.**