### PR TITLE
Updated dependancys and Gtk version req

### DIFF
--- a/client/totp_enrollment.py
+++ b/client/totp_enrollment.py
@@ -15,6 +15,13 @@ except ImportError:
 else:
 	has_qrcode = True
 
+try:
+	import PIL
+except ImportError:
+	has_pillow = False
+else:
+	has_pillow = True
+
 gtk_builder_file = os.path.splitext(__file__)[0] + '.ui'
 
 class Plugin(plugins.ClientPlugin):
@@ -29,7 +36,8 @@ class Plugin(plugins.ClientPlugin):
 	homepage = 'https://github.com/securestate/king-phisher-plugins'
 	req_min_version = '1.7.0b2'
 	req_packages = {
-		'qrcode': has_qrcode
+		'qrcode': has_qrcode,
+		'Pillow': has_pil
 	}
 	def initialize(self):
 		if not os.access(gtk_builder_file, os.R_OK):

--- a/client/totp_enrollment.py
+++ b/client/totp_enrollment.py
@@ -37,7 +37,7 @@ class Plugin(plugins.ClientPlugin):
 	req_min_version = '1.7.0b2'
 	req_packages = {
 		'qrcode': has_qrcode,
-		'Pillow': has_pil
+		'pillow': has_pillow
 	}
 	def initialize(self):
 		if not os.access(gtk_builder_file, os.R_OK):

--- a/client/totp_enrollment.ui
+++ b/client/totp_enrollment.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkApplicationWindow" id="TOTPEnrollment.window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">TOTP Enrollment</property>


### PR DESCRIPTION
# Description
This PR updates TOPT self enrollment plugin with additionally required packages, and changes the UI file Gtk required version from 3.20 to 3.10. These changes are to allow it to run on more of the supported Operating systems of King Phisher, and displays all the required missing packages.

# Testing
- [x] Will now display Pillow as a required python package.
- [x] Will now run on Gtk Version 3.10 and higher

cc: @jamcut