### PR TITLE
Permission set working directory

### DIFF
--- a/client/sftp_client/directory.py
+++ b/client/sftp_client/directory.py
@@ -212,10 +212,31 @@ class DirectoryBase(object):
 			new_dir = self.get_abspath(new_dir)
 		if new_dir == self.cwd:
 			return
-		self._chdir(new_dir)
-		self.cwd = new_dir
+		try:
+			self._chdir(new_dir)
+		except PermissionError:
+			logger.warning("User does not have permissions to read {}".format(new_dir))
+			gui_utilities.show_dialog_error(
+				'Plugin Error',
+				self.application.get_active_window(),
+				"You do not have permissions to access {}.".format(new_dir)
+			)
+			return
+
 		self._tv_model.clear()
-		self.load_dirs(new_dir)
+		try:
+			self.load_dirs(new_dir)
+		except PermissionError:
+			logger.warning("User does not have permissions to read {}".format(new_dir))
+			self.load_dirs(self.cwd)
+			gui_utilities.show_dialog_error(
+				'Plugin Error',
+				self.application.get_active_window(),
+				"You do not have permissions to access {}.".format(new_dir)
+			)
+			return
+
+		self.cwd = new_dir
 		# clear and rebuild the model
 		self._wdcb_model.clear()
 		self._wdcb_model.append((self.root_directory,))


### PR DESCRIPTION
# Fix issue for Permission Error handling
This pr fixes the stack trace when you try to set the working directory, where you do not have permissions to access the folder.

The try block on line 215 in the directories file, will catch the permission error for LocalDirectory instance, and the try block on line 227 will catch the issue for RemoteDirectory instance. As the FTP will 'change directory' then try to read. Where locally the permissions are checked during the change of the directory.

- [x] Tells the user they do not have permissions to set the folder as the working directory.

KP-65