### PR TITLE
SFTP Editor v1.3

### DIFF
--- a/client/sftp_client/__init__.py
+++ b/client/sftp_client/__init__.py
@@ -2,6 +2,7 @@ import os
 import paramiko
 
 from . import client
+from . import sftp_utilities
 
 from king_phisher.client import gui_utilities
 from king_phisher.client import plugins
@@ -24,11 +25,11 @@ class Plugin(plugins.ClientPlugin):
 	def initialize(self):
 		"""Connects to the start SFTP Client Signal to the plugin and checks for .ui file."""
 		self.sftp_window = None
-		if not os.access(client.gtk_builder_file, os.R_OK):
+		if not os.access(sftp_utilities.gtk_builder_file, os.R_OK):
 			gui_utilities.show_dialog_error(
 				'Plugin Error',
 				self.application.get_active_window(),
-				"The GTK Builder data file ({0}) is not available.".format(os.path.basename(client.gtk_builder_file))
+				"The GTK Builder data file ({0}) is not available.".format(os.path.basename(sftp_utilities.gtk_builder_file))
 			)
 			return False
 		if 'directories' not in self.config:
@@ -59,7 +60,7 @@ class Plugin(plugins.ClientPlugin):
 				)
 				return
 			ssh = connection.client
-			self.logger.debug('loading gtk builder file from: ' + client.gtk_builder_file)
+			self.logger.debug('loading gtk builder file from: ' + sftp_utilities.gtk_builder_file)
 			try:
 				manager = client.FileManager(self.application, ssh, self.config)
 			except paramiko.ssh_exception.ChannelException as error:

--- a/client/sftp_client/__init__.py
+++ b/client/sftp_client/__init__.py
@@ -17,11 +17,11 @@ class Plugin(plugins.ClientPlugin):
 	create, and delete local and remote files on the King Phisher Server.
 	
 	The editor allows you edit files on remote or local system. It is primarily
-	designed for the use of editing remote landing pages on the King Phisher Server.
+	designed for the use of editing remote web pages on the King Phisher Server.
 	"""
 	homepage = 'https://github.com/securestate/king-phisher'
 	req_min_version = '1.4.0b0'
-	version = '1.2'
+	version = '1.3'
 	def initialize(self):
 		"""Connects to the start SFTP Client Signal to the plugin and checks for .ui file."""
 		self.sftp_window = None

--- a/client/sftp_client/client.py
+++ b/client/sftp_client/client.py
@@ -468,6 +468,7 @@ class FileManager(object):
 		self.config['directories'] = directories
 		self.editor = None
 		sftp_utilities._gtk_objects = {}
+		sftp_utilities._builder = None
 
 	def _queue_transfer_from_selection(self, task_cls):
 		selection = self.local.treeview.get_selection()

--- a/client/sftp_client/client.py
+++ b/client/sftp_client/client.py
@@ -10,6 +10,7 @@ import boltons.timeutils
 from . import tasks
 from . import directory
 from . import sftp_utilities
+from . import editor
 
 from king_phisher.client import gui_utilities
 
@@ -18,7 +19,7 @@ from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import GLib
 
-gtk_builder_file = os.path.splitext(__file__)[0] + '.ui'
+#gtk_builder_file = os.path.splitext(__file__)[0] + '.ui'
 logger = logging.getLogger('KingPhisher.Plugins.SFTPClient')
 
 class StatusDisplay(object):
@@ -26,11 +27,10 @@ class StatusDisplay(object):
 	Class representing the bottom treeview of the GUI. This contains the logging
 	and graphical representation of all queued transfers.
 	"""
-	def __init__(self, builder, queue):
-		self.builder = builder
+	def __init__(self, queue):
 		self.queue = queue
-		self.scroll = self.builder.get_object('SFTPClient.notebook.page_stfp.scrolledwindow_transfer_statuses')
-		self.treeview_transfer = self.builder.get_object('SFTPClient.notebook.page_stfp.treeview_transfer_statuses')
+		self.scroll = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.scrolledwindow_transfer_statuses')
+		self.treeview_transfer = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.treeview_transfer_statuses')
 		self._tv_lock = threading.RLock()
 
 		col_text = Gtk.CellRendererText()
@@ -216,27 +216,68 @@ class FileManager(object):
 			thread = threading.Thread(target=self._thread_routine)
 			thread.start()
 			self._threads.append(thread)
-		self.builder = Gtk.Builder()
-		self.builder.add_from_file(gtk_builder_file)
-		self.window = self.builder.get_object('SFTPClient.window')
-		self.notebook = self.builder.get_object('SFTPClient.notebook')
-		self.status_display = StatusDisplay(self.builder, self.queue)
-		self.local = directory.LocalDirectory(self.builder, self.application, config)
-		self.remote = directory.RemoteDirectory(self.builder, self.application, config, ssh)
-		self.builder.get_object('SFTPClient.notebook.page_stfp.button_upload').connect('button-press-event', lambda widget, event: self._queue_transfer_from_selection(tasks.UploadTask))
-		self.builder.get_object('SFTPClient.notebook.page_stfp.button_download').connect('button-press-event', lambda widget, event: self._queue_transfer_from_selection(tasks.DownloadTask))
+		self.editor = None
+		self.window = sftp_utilities.get_object('SFTPClient.window')
+		self.notebook = sftp_utilities.get_object('SFTPClient.notebook')
+		self.editor_tab_save_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_save_html_file')
+		self.editor_tab_save_button.set_sensitive(False)
+		self.editor_tab_save_button.connect('clicked', self.signal_editor_save)
+		self.status_display = StatusDisplay(self.queue)
+		self.local = directory.LocalDirectory(self.application, config)
+		self.remote = directory.RemoteDirectory(self.application, config, ssh)
+		sftp_utilities.get_object('SFTPClient.notebook.page_stfp.button_upload').connect('button-press-event', lambda widget, event: self._queue_transfer_from_selection(tasks.UploadTask))
+		sftp_utilities.get_object('SFTPClient.notebook.page_stfp.button_download').connect('button-press-event', lambda widget, event: self._queue_transfer_from_selection(tasks.DownloadTask))
 		self.local.menu_item_transfer.connect('activate', lambda widget: self._queue_transfer_from_selection(tasks.UploadTask))
 		self.remote.menu_item_transfer.connect('activate', lambda widget: self._queue_transfer_from_selection(tasks.DownloadTask))
-		menu_item = self.builder.get_object('SFTPClient.notebook.page_stfp.menuitem_opts_transfer_hidden')
+		self.local.menu_item_edit.connect('activate', self.signal_edit_local_file)
+		self.remote.menu_item_edit.connect('activate', self.signal_edit_remote_file)
+		menu_item = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.menuitem_opts_transfer_hidden')
 		menu_item.set_active(self.config['transfer_hidden'])
 		menu_item.connect('toggled', self.signal_toggled_config_option, 'transfer_hidden')
-		menu_item = self.builder.get_object('SFTPClient.notebook.page_stfp.menuitem_opts_show_hidden')
+		menu_item = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.menuitem_opts_show_hidden')
 		menu_item.set_active(self.config['show_hidden'])
 		menu_item.connect('toggled', self.signal_toggled_config_option_show_hidden)
-		menu_item = self.builder.get_object('SFTPClient.notebook.page_stfp.menuitem_exit')
+		menu_item = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.menuitem_exit')
 		menu_item.connect('activate', lambda _: self.window.destroy())
 		self.window.connect('destroy', self.signal_window_destroy)
 		self.window.show_all()
+
+	def signal_edit_local_file(self, _):
+		selection = self.local.treeview.get_selection()
+		model, treeiter = selection.get_selected()
+		local_file_path = self.local.get_abspath(model[treeiter][2])
+		try:
+			file_contents = self.local.read_file(local_file_path)
+		except ValueError:
+			logger.warning("cannot read file {}".format(local_file_path))
+			gui_utilities.show_dialog_error(
+				'Permission Denied',
+				self.application.get_active_window(),
+				'Cannot read to the file.'
+			)
+			return
+		self.editor = editor.SftpEditor(file_contents, local_file_path, 'local')
+
+	def signal_edit_remote_file(self, _):
+		selection = self.remote.treeview.get_selection()
+		model, treeiter = selection.get_selected()
+		remote_file_path = self.remote.get_abspath(model[treeiter][2])
+		try:
+			file_contents = self.remote.ftp_read_file(remote_file_path)
+			print(type(file_contents))
+		except IOError:
+			logger.warning("cannot read remote file {}".format(remote_file_path))
+			gui_utilities.show_dialog_error(
+				'Permission Denied',
+				self.application.get_active_window(),
+				'Cannot read remote file'
+			)
+			return
+		print("Type of file contents going into editor {}".format(type(file_contents)))
+		self.editor = editor.SftpEditor(file_contents, remote_file_path, 'remote')
+
+	def signal_editor_save(self, _):
+		self._save_editor_file()
 
 	def signal_toggled_config_option(self, menuitem, config_key):
 		self.config[config_key] = menuitem.get_active()
@@ -245,6 +286,46 @@ class FileManager(object):
 		self.config['show_hidden'] = menuitem.get_active()
 		self.local.refilter()
 		self.remote.refilter()
+
+	def _save_editor_file(self):
+		if not self.editor:
+			self.editor_tab_save_button.set_sensitive(False)
+			return
+
+		buffer_contents = self.editor.sourceview_buffer.get_text(
+			self.editor.sourceview_buffer.get_start_iter(),
+			self.editor.sourceview_buffer.get_end_iter(),
+			False
+		)
+		if buffer_contents == self.editor.file_contents:
+			logger.info('no changes found in file')
+			return
+
+		if self.editor.location == 'local':
+			if not (self.editor.file_path and os.path.isfile(self.editor.file_path) and os.access(self.editor.file_path, os.W_OK)):
+				self.editor_tab_save_button.set_sensitive(False)
+				gui_utilities.show_dialog_error(
+					'Permission Denied',
+					self.application.get_active_window(),
+					'Cannot write to local file'
+				)
+			file = open(self.editor.file_path, 'w')
+			file.write(buffer_contents)
+			file.close()
+			self.editor.file_contents = buffer_contents
+			logger.info('saved edited to file {}'.format(self.editor.file_path))
+			return
+		elif self.editor.location == 'remote':
+			try:
+				self.remote.ftp_save_file(self.editor.file_path, buffer_contents)
+				self.editor.file_contents = buffer_contents
+			except IOError:
+				self.editor_tab_save_button.set_sensitive(False)
+				gui_utilities.show_dialog_error(
+					'Permission Denied',
+					self.application.get_active_window(),
+					'Cannot write to remote file'
+				)
 
 	def _transfer_dir(self, task):
 		task.state = 'Transferring'
@@ -345,6 +426,7 @@ class FileManager(object):
 			directories['remote'] = {}
 		directories['remote'][self.application.config['server'].split(':', 1)[0]] = list(self.remote.wd_history)
 		self.config['directories'] = directories
+		sftp_utilities._gtk_objects = {}
 
 	def _queue_transfer_from_selection(self, task_cls):
 		selection = self.local.treeview.get_selection()

--- a/client/sftp_client/client.ui
+++ b/client/sftp_client/client.ui
@@ -375,6 +375,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="tooltip_text" translatable="yes">Save</property>
+                    <property name="margin_left">3</property>
+                    <property name="margin_right">3</property>
                     <property name="label" translatable="yes">Save</property>
                     <property name="use_underline">True</property>
                     <property name="stock_id">gtk-save</property>
@@ -389,6 +391,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="tooltip_text" translatable="yes">Web Page Template Help</property>
+                    <property name="margin_left">3</property>
+                    <property name="margin_right">3</property>
                     <property name="label" translatable="yes">Template Help</property>
                     <property name="use_underline">True</property>
                     <property name="stock_id">gtk-info</property>
@@ -426,6 +430,26 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="SFTPClient.notebook.page_editor.statusbar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">10</property>
+                <property name="margin_right">10</property>
+                <property name="margin_start">10</property>
+                <property name="margin_end">10</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>

--- a/client/sftp_client/client.ui
+++ b/client/sftp_client/client.ui
@@ -21,7 +21,6 @@
         <property name="height_request">500</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
-        <property name="show_tabs">False</property>
         <property name="scrollable">True</property>
         <child>
           <object class="GtkBox" id="SFTPClient.notebook.page_stfp.box">
@@ -389,7 +388,7 @@
                   <object class="GtkToolButton" id="SFTPClient.notebook.page_editor.toolbutton_template_wiki">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="tooltip_text" translatable="yes">Message Template Help</property>
+                    <property name="tooltip_text" translatable="yes">Web Page Template Help</property>
                     <property name="label" translatable="yes">Template Help</property>
                     <property name="use_underline">True</property>
                     <property name="stock_id">gtk-info</property>

--- a/client/sftp_client/directory.py
+++ b/client/sftp_client/directory.py
@@ -612,34 +612,35 @@ class LocalDirectory(DirectoryBase):
 			return True
 		return False
 
-	def read_file(self, local_file_path):
+	def read_file(self, file_path):
 		"""
-		Used to fetch the contents of target file
-		:param str local_file_path: the absolute path to target file
-		:return: the utf-8 contents of the file
-		:rtype: str
+		Reads the contents of a file and returns as bytes
+
+		:param str file_path: The path to the file to open and read. 
+		:return: The contents of the file
+		:rtype: bytes
 		"""
-		if not (local_file_path and os.path.isfile(local_file_path) and os.access(local_file_path, os.R_OK)):
+		if not (file_path and os.path.isfile(file_path) and os.access(file_path, os.R_OK)):
 			logger.warning('cannot write to local file, or file not found')
-			raise ValueError("Cannot read file {}".format(local_file_path))
-		with open(local_file_path, 'r') as file_:
+			raise ValueError("Cannot read file {}".format(file_path))
+		with open(file_path, 'rb') as file_:
 			file_contents = file_.read()
 		return file_contents
 
-	def save_file(self, local_file_path, buffer_contents):
+	def save_file(self, file_path, file_contents):
 		"""
 		Saves a string to a file
 
-		:param str local_file_path: The absolute path to target file.
-		:param str buffer_contents: The data to place in file.
+		:param str file_path: The absolute path to target file.
+		:param str file_contents: The data to place in file.
 		"""
-		if not (local_file_path and os.path.isfile(local_file_path) and os.access(local_file_path, os.W_OK)):
+		if not (file_path and os.path.isfile(file_path) and os.access(file_path, os.W_OK)):
 			logger.warning('cannot write to local file, or file not found')
 			raise IOError("Cannot write to local file, or file not found")
-		file_ = open(local_file_path, 'w')
-		file_.write(buffer_contents)
+		file_ = open(file_path, 'w')
+		file_.write(file_contents)
 		file_.close()
-		logger.info('saved edited to file {}'.format(local_file_path))
+		logger.info('saved edited to file {}'.format(file_path))
 
 	@sftp_utilities.handle_permission_denied
 	def delete(self, treeiter):
@@ -868,10 +869,10 @@ class RemoteDirectory(DirectoryBase):
 
 	def save_file(self, file_path, file_contents):
 		"""
-		Saves a raw string to the remote file path
-		
-		:param str file_path: Remote file path
-		:param str file_contents: the contents to place in the file
+		Saves a string to a file
+
+		:param str file_path: The absolute path to target file.
+		:param str file_contents: The data to place in file.
 		"""
 		with self.ftp_handle() as ftp:
 			file_ = ftp.file(file_path, 'w')

--- a/client/sftp_client/directory.py
+++ b/client/sftp_client/directory.py
@@ -13,6 +13,7 @@ import boltons.strutils
 import boltons.timeutils
 
 from . import sftp_utilities
+from . import editor
 
 from king_phisher import its
 from king_phisher import utilities
@@ -39,12 +40,11 @@ class DirectoryBase(object):
 	Base directory object that is used by both the remote and local directory to
 	get and render directory data.
 	"""
-	def __init__(self, builder, application, config, wd_history):
-		self.builder = builder
+	def __init__(self, application, config, wd_history):
 		self.application = application
 		self.config = config
-		self.treeview = self.builder.get_object('SFTPClient.notebook.page_stfp.' + self.treeview_name)
-		self.notebook = self.builder.get_object('SFTPClient.notebook')
+		self.treeview = sftp_utilities.get_object('SFTPClient.notebook.page_stfp.' + self.treeview_name)
+		self.notebook = sftp_utilities.get_object('SFTPClient.notebook')
 		self.wd_history = collections.deque(wd_history, maxlen=3)
 		self.cwd = None
 		self.col_name = Gtk.CellRendererText()
@@ -86,7 +86,7 @@ class DirectoryBase(object):
 		self.treeview.set_model(self._tv_model_sort)
 
 		self._wdcb_model = Gtk.ListStore(str)  # working directory combobox
-		self.wdcb_dropdown = builder.get_object(self.working_directory_combobox_name)
+		self.wdcb_dropdown = sftp_utilities.get_object(self.working_directory_combobox_name)
 		self.wdcb_dropdown.set_model(self._wdcb_model)
 		self.wdcb_dropdown.set_entry_text_column(0)
 		self.wdcb_dropdown.connect('changed', sftp_utilities.DelayedChangedSignal(self.signal_combo_changed))
@@ -146,6 +146,9 @@ class DirectoryBase(object):
 
 		self.menu_item_transfer = Gtk.MenuItem.new_with_label(self.transfer_direction.title())
 		self.popup_menu.append(self.menu_item_transfer)
+
+		self.menu_item_edit = Gtk.MenuItem.new_with_label('Edit')
+		self.popup_menu.append(self.menu_item_edit)
 
 		menu_item = Gtk.MenuItem.new_with_label('Collapse All')
 		menu_item.connect('activate', self.signal_menu_activate_collapse_all)
@@ -321,6 +324,15 @@ class DirectoryBase(object):
 	def shutdown(self):
 		"""Perform any necessary clean up operations."""
 		pass
+
+	def signal_edit_file(self, _):
+		location = None
+		if isinstance(self, RemoteDirectory):
+			location = 'remote'
+		elif isinstance(self, LocalDirectory):
+			location = 'local'
+		if location:
+			editor.SftpEditor(self, location)
 
 	def signal_combo_changed(self, combobox):
 		new_dir = combobox.get_active_text()
@@ -565,14 +577,14 @@ class LocalDirectory(DirectoryBase):
 	transfer_direction = 'upload'
 	treeview_name = 'treeview_local'
 	working_directory_combobox_name = 'SFTPClient.notebook.page_stfp.comboboxtext_local_working_directory'
-	def __init__(self, builder, application, config):
+	def __init__(self, application, config):
 		self.stat = os.stat
 		self._chdir = os.chdir
 		self.path_mod = os.path
 		self.default_directory = self.path_mod.expanduser('~')
 		local_directories = config['directories'].get('local', {})
 		wd_history = local_directories.get('history', [])
-		super(LocalDirectory, self).__init__(builder, application, config, wd_history)
+		super(LocalDirectory, self).__init__(application, config, wd_history)
 		current_directory = local_directories.get('current')
 		if current_directory is None or not os.access(current_directory, os.R_OK):
 			current_directory = self.default_directory
@@ -607,6 +619,13 @@ class LocalDirectory(DirectoryBase):
 		elif self.path_mod.basename(path).startswith('.'):
 			return True
 		return False
+
+	def read_file(self, local_file_path):
+		if not (local_file_path and os.path.isfile(local_file_path) and os.access(local_file_path, os.R_OK)):
+			raise ValueError("Cannot read file {}".format(local_file_path))
+		with open(local_file_path, 'r') as f:
+			file_contents = f.read()
+		return file_contents
 
 	@sftp_utilities.handle_permission_denied
 	def delete(self, treeiter):
@@ -666,13 +685,13 @@ class RemoteDirectory(DirectoryBase):
 	transfer_direction = 'download'
 	treeview_name = 'treeview_remote'
 	working_directory_combobox_name = 'SFTPClient.notebook.page_stfp.comboboxtext_remote_working_directory'
-	def __init__(self, builder, application, config, ssh):
+	def __init__(self, application, config, ssh):
 		self.ssh = ssh
 		self.path_mod = posixpath
 		wd_history = config['directories'].get('remote', {})
 		wd_history = wd_history.get(application.config['server'].split(':', 1)[0], [])
 		self._thread_local_ftp = {}
-		super(RemoteDirectory, self).__init__(builder, application, config, wd_history)
+		super(RemoteDirectory, self).__init__(application, config, wd_history)
 
 		self.default_directory = application.config['server_config']['server.web_root']
 		try:
@@ -818,6 +837,32 @@ class RemoteDirectory(DirectoryBase):
 		"""
 		with self.ftp_handle() as ftp:
 			ftp.remove(name)
+
+	def ftp_read_file(self, file_path):
+		"""
+		Reads the contents of a file and returns as a string
+
+		:param str file_path: The path to the file to open and read. 
+		:return: The contents of the file
+		:rtype: bytes
+		"""
+		with self.ftp_handle() as ftp:
+			with ftp.file(file_path, 'r') as file:
+				file_contents = file.read()
+		print("file contents from remote ftp is {}".format(type(file_contents)))
+		return file_contents
+
+	def ftp_save_file(self, file_path, file_contents):
+		"""
+		Saves a raw string to the remote file path
+		
+		:param file_path: Remote file path
+		:param file_contents: the contents to place in the file
+		"""
+		with self.ftp_handle() as ftp:
+			file = ftp.file(file_path, 'w')
+			file.write(file_contents)
+			file.close()
 
 	def walk(self, path):
 		"""

--- a/client/sftp_client/directory.py
+++ b/client/sftp_client/directory.py
@@ -325,15 +325,6 @@ class DirectoryBase(object):
 		"""Perform any necessary clean up operations."""
 		pass
 
-	def signal_edit_file(self, _):
-		location = None
-		if isinstance(self, RemoteDirectory):
-			location = 'remote'
-		elif isinstance(self, LocalDirectory):
-			location = 'local'
-		if location:
-			editor.SftpEditor(self, location)
-
 	def signal_combo_changed(self, combobox):
 		new_dir = combobox.get_active_text()
 		if not new_dir:
@@ -573,6 +564,7 @@ class LocalDirectory(DirectoryBase):
 	Local Directory object that defines private methods for rendering local data
 	using the os module.
 	"""
+	location = 'local'
 	root_directory = os.path.abspath(os.sep)
 	transfer_direction = 'upload'
 	treeview_name = 'treeview_local'
@@ -703,6 +695,7 @@ class RemoteDirectory(DirectoryBase):
 	Remote Directory object that defines private methods for rendering remote
 	data using Paramiko's SFTP functionality.
 	"""
+	location = 'remote'
 	root_directory = posixpath.abspath(posixpath.sep)
 	transfer_direction = 'download'
 	treeview_name = 'treeview_remote'

--- a/client/sftp_client/directory.py
+++ b/client/sftp_client/directory.py
@@ -628,10 +628,10 @@ class LocalDirectory(DirectoryBase):
 		:rtype: str
 		"""
 		if not (local_file_path and os.path.isfile(local_file_path) and os.access(local_file_path, os.R_OK)):
-			logger.warning('no path given')
+			logger.warning('cannot write to local file, or file not found')
 			raise ValueError("Cannot read file {}".format(local_file_path))
-		with open(local_file_path, 'r') as f:
-			file_contents = f.read()
+		with open(local_file_path, 'r') as file_:
+			file_contents = file_.read()
 		return file_contents
 
 	def save_file(self, local_file_path, buffer_contents):
@@ -644,9 +644,9 @@ class LocalDirectory(DirectoryBase):
 		if not (local_file_path and os.path.isfile(local_file_path) and os.access(local_file_path, os.W_OK)):
 			logger.warning('cannot write to local file, or file not found')
 			raise IOError("Cannot write to local file, or file not found")
-		file = open(local_file_path, 'w')
-		file.write(buffer_contents)
-		file.close()
+		file_ = open(local_file_path, 'w')
+		file_.write(buffer_contents)
+		file_.close()
 		logger.info('saved edited to file {}'.format(local_file_path))
 
 	@sftp_utilities.handle_permission_denied
@@ -860,7 +860,7 @@ class RemoteDirectory(DirectoryBase):
 		with self.ftp_handle() as ftp:
 			ftp.remove(name)
 
-	def ftp_read_file(self, file_path):
+	def read_file(self, file_path):
 		"""
 		Reads the contents of a file and returns as bytes
 
@@ -869,11 +869,11 @@ class RemoteDirectory(DirectoryBase):
 		:rtype: bytes
 		"""
 		with self.ftp_handle() as ftp:
-			with ftp.file(file_path, 'r') as file:
-				file_contents = file.read()
+			with ftp.file(file_path, 'r') as file_:
+				file_contents = file_.read()
 		return file_contents
 
-	def ftp_save_file(self, file_path, file_contents):
+	def save_file(self, file_path, file_contents):
 		"""
 		Saves a raw string to the remote file path
 		
@@ -881,9 +881,9 @@ class RemoteDirectory(DirectoryBase):
 		:param str file_contents: the contents to place in the file
 		"""
 		with self.ftp_handle() as ftp:
-			file = ftp.file(file_path, 'w')
-			file.write(file_contents)
-			file.close()
+			file_ = ftp.file(file_path, 'w')
+			file_.write(file_contents)
+			file_.close()
 
 	def walk(self, path):
 		"""

--- a/client/sftp_client/editor.py
+++ b/client/sftp_client/editor.py
@@ -13,25 +13,19 @@ class SFTPEditor(object):
 	"""
 	Handles the editor tab functions
 	"""
-	def __init__(self, file_path, directory, location):
+	def __init__(self, file_path, directory):
 		"""
 		This class is used to set up the Gtk.SourceView instance to edit the file
 
-		:param str file_contents: 
 		:param str file_path: the path of the file to edit
 		:param directory: the local or remote directory instance
-		:param str location: the locate either remote or local
 		"""
 		# get editor tab objects
-		if location not in ('Remote', 'Local'):
-			logger.warning("location must be remote or local not {}".format(location))
-			return
-		self.location = location
+		self.file_location = directory.location
 		self.file_path = file_path
 		self.file_contents = None
 		self.directory = directory
 
-		self.notebook = sftp_utilities.get_object('SFTPClient.notebook')
 		self.sourceview_editor = sftp_utilities.get_object('SFTPClient.notebook.page_editor.sourceview')
 		self.save_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_save_html_file')
 		self.template_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_template_wiki')
@@ -69,9 +63,8 @@ class SFTPEditor(object):
 		self.sourceview_buffer.end_not_undoable_action()
 		self.save_button.set_sensitive(False)
 		self.sourceview_buffer.set_highlight_syntax(True)
-		self.statusbar.push(self.statusbar.get_context_id(self.location + ' File: ' + self.file_path), self.location + ' File: ' + self.file_path)
-		self.notebook.set_current_page(1)
-		logger.info("sftp editor set to {} file {}".format(self.location, self.file_path))
+		self.statusbar.push(self.statusbar.get_context_id(self.file_location + ' file: ' + self.file_path), self.file_location + ' file: ' + self.file_path)
+		logger.info("sftp editor set to {} file {}".format(self.file_location, self.file_path))
 
 	def signal_template_help(self, _):
 		utilities.open_uri('https://github.com/securestate/king-phisher/wiki/Templates#web-page-templates')

--- a/client/sftp_client/editor.py
+++ b/client/sftp_client/editor.py
@@ -5,8 +5,8 @@ from . import sftp_utilities
 
 from king_phisher.client.widget import completion_providers
 from king_phisher import utilities
+from king_phisher.client import gui_utilities
 
-from gi.repository import Gtk
 from gi.repository import GtkSource
 
 logger = logging.getLogger('KingPhisher.Plugins.SFTPClient.editor')
@@ -17,14 +17,19 @@ class SftpEditor(object):
 	"""
 	def __init__(self, file_contents, file_path, location):
 		"""
-		
-		:param file_contents: the contents of the file to be edited
-		:param str location: local or remote connection
+		This class is used to set up the Gtk.SourceView instance to edit the file
+
+		:param str file_contents: 
+		:param file_path: the path of the file to edit
+		:param location: the locate either remote or local
 		"""
 		# get editor tab objects
 		if not isinstance(file_contents, str):
-			print("error got file_contents type of {}".format(type(file_contents)))
-			file_contents = file_contents.decode()
+			logger.info("error got file_contents type of {} should be utf-8 string".format(type(file_contents)))
+			file_contents = file_contents.decode('utf-8')
+		if location not in ('Remote', 'Local'):
+			logger.warning("location must be remote or local not {}".format(location))
+			return
 		self.location = location
 		self.file_path = file_path
 		self.file_contents = file_contents
@@ -34,6 +39,7 @@ class SftpEditor(object):
 		self.save_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_save_html_file')
 		self.template_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_template_wiki')
 		self.template_button.connect('clicked', self.signal_template_help)
+		self.statusbar = sftp_utilities.get_object('SFTPClient.notebook.page_editor.statusbar')
 
 		# set up sourceview for editing
 		self.sourceview_editor.set_buffer(GtkSource.Buffer())
@@ -41,10 +47,18 @@ class SftpEditor(object):
 		self.sourceview_buffer = self.sourceview_editor.get_buffer()
 		language_manager = GtkSource.LanguageManager()
 		self.sourceview_buffer.set_language(language_manager.get_language('html'))
-		self.view_completion.add_provider(completion_providers.HTMLComletionProvider())
-		self.view_completion.add_provider(completion_providers.JinjaPageComletionProvider())
+		if not self.view_completion.get_providers():
+			self.view_completion.add_provider(completion_providers.HTMLComletionProvider())
+			self.view_completion.add_provider(completion_providers.JinjaPageComletionProvider())
+			logger.info('successfully loaded HTML and Jinja comletion providers')
+		self.sourceview_buffer.connect('changed', self.signal_buff_changed)
 
 		self._loadfile()
+
+	def signal_buff_changed(self, _):
+		if self.save_button.is_sensitive():
+			return
+		self.save_button.set_sensitive(True)
 
 	def _loadfile(self):
 		self.sourceview_buffer.begin_not_undoable_action()
@@ -55,9 +69,11 @@ class SftpEditor(object):
 			False
 		)
 		self.sourceview_buffer.end_not_undoable_action()
-		self.save_button.set_sensitive(True)
+		self.save_button.set_sensitive(False)
 		self.sourceview_buffer.set_highlight_syntax(True)
+		self.statusbar.push(self.statusbar.get_context_id(self.location + ' File: ' + self.file_path), self.location + ' File: ' + self.file_path)
 		self.notebook.set_current_page(1)
+		logger.info("sftp editor set to {} file {}".format(self.location, self.file_path))
 
 	def signal_template_help(self, _):
 		utilities.open_uri('https://github.com/securestate/king-phisher/wiki/Templates#web-page-templates')

--- a/client/sftp_client/editor.py
+++ b/client/sftp_client/editor.py
@@ -1,0 +1,65 @@
+import os
+import logging
+
+from . import sftp_utilities
+
+from king_phisher.client.widget import completion_providers
+from king_phisher import utilities
+
+from gi.repository import Gtk
+from gi.repository import GtkSource
+
+logger = logging.getLogger('KingPhisher.Plugins.SFTPClient.editor')
+
+class SftpEditor(object):
+	"""
+	Handles the editor tab functions
+	"""
+	def __init__(self, file_contents, file_path, location):
+		"""
+		
+		:param file_contents: the contents of the file to be edited
+		:param str location: local or remote connection
+		"""
+		# get editor tab objects
+		if not isinstance(file_contents, str):
+			print("error got file_contents type of {}".format(type(file_contents)))
+			file_contents = file_contents.decode()
+		self.location = location
+		self.file_path = file_path
+		self.file_contents = file_contents
+
+		self.notebook = sftp_utilities.get_object('SFTPClient.notebook')
+		self.sourceview_editor = sftp_utilities.get_object('SFTPClient.notebook.page_editor.sourceview')
+		self.save_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_save_html_file')
+		self.template_button = sftp_utilities.get_object('SFTPClient.notebook.page_editor.toolbutton_template_wiki')
+		self.template_button.connect('clicked', self.signal_template_help)
+
+		# set up sourceview for editing
+		self.sourceview_editor.set_buffer(GtkSource.Buffer())
+		self.view_completion = self.sourceview_editor.get_completion()
+		self.sourceview_buffer = self.sourceview_editor.get_buffer()
+		language_manager = GtkSource.LanguageManager()
+		self.sourceview_buffer.set_language(language_manager.get_language('html'))
+		self.view_completion.add_provider(completion_providers.HTMLComletionProvider())
+		self.view_completion.add_provider(completion_providers.JinjaPageComletionProvider())
+
+		self._loadfile()
+
+	def _loadfile(self):
+		self.sourceview_buffer.begin_not_undoable_action()
+		self.sourceview_buffer.set_text(self.file_contents)
+		self.file_contents = self.sourceview_buffer.get_text(
+			self.sourceview_buffer.get_start_iter(),
+			self.sourceview_buffer.get_end_iter(),
+			False
+		)
+		self.sourceview_buffer.end_not_undoable_action()
+		self.save_button.set_sensitive(True)
+		self.sourceview_buffer.set_highlight_syntax(True)
+		self.notebook.set_current_page(1)
+
+	def signal_template_help(self, _):
+		utilities.open_uri('https://github.com/securestate/king-phisher/wiki/Templates#web-page-templates')
+
+

--- a/client/sftp_client/sftp_utilities.py
+++ b/client/sftp_client/sftp_utilities.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+import os
 
 from king_phisher.client import gui_utilities
 
@@ -9,6 +10,20 @@ from gi.repository import GObject
 
 logger = logging.getLogger('KingPhisher.Plugins.SFTPClient')
 GTYPE_LONG = GObject.type_from_name('glong')
+gtk_builder_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'client.ui')
+_gtk_objects = {}
+_builder = Gtk.Builder()
+
+def get_object(gtk_object):
+	if not _gtk_objects:
+		_builder.add_from_file(gtk_builder_file)
+	if gtk_object in _gtk_objects:
+		print('--------found gtk object----------')
+		return _gtk_objects[gtk_object]
+	else:
+		print('adding {} gtk object'.format(gtk_object))
+		_gtk_objects[gtk_object] = _builder.get_object(gtk_object)
+		return _gtk_objects[gtk_object]
 
 class DelayedChangedSignal(object):
 	def __init__(self, handler, delay=500):

--- a/client/sftp_client/sftp_utilities.py
+++ b/client/sftp_client/sftp_utilities.py
@@ -8,20 +8,24 @@ from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import GObject
 
-logger = logging.getLogger('KingPhisher.Plugins.SFTPClient')
+logger = logging.getLogger('KingPhisher.Plugins.SFTPClient.utilities')
 GTYPE_LONG = GObject.type_from_name('glong')
 gtk_builder_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'client.ui')
 _gtk_objects = {}
 _builder = Gtk.Builder()
 
 def get_object(gtk_object):
+	"""
+	Used to maintain a diction of GTK objects to share through the SFTP Client
+
+	:param str gtk_object: The name of the GTK Object to fetch
+	:return: The requested gtk object
+	"""
 	if not _gtk_objects:
 		_builder.add_from_file(gtk_builder_file)
 	if gtk_object in _gtk_objects:
-		print('--------found gtk object----------')
 		return _gtk_objects[gtk_object]
 	else:
-		print('adding {} gtk object'.format(gtk_object))
 		_gtk_objects[gtk_object] = _builder.get_object(gtk_object)
 		return _gtk_objects[gtk_object]
 

--- a/client/sftp_client/sftp_utilities.py
+++ b/client/sftp_client/sftp_utilities.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('KingPhisher.Plugins.SFTPClient.utilities')
 GTYPE_LONG = GObject.type_from_name('glong')
 gtk_builder_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'client.ui')
 _gtk_objects = {}
-_builder = Gtk.Builder()
+_builder = None
 
 def get_object(gtk_object):
 	"""
@@ -21,6 +21,9 @@ def get_object(gtk_object):
 	:param str gtk_object: The name of the GTK Object to fetch
 	:return: The requested gtk object
 	"""
+	global _builder
+	if not _builder:
+		_builder = Gtk.Builder()
 	if not _gtk_objects:
 		_builder.add_from_file(gtk_builder_file)
 	if gtk_object in _gtk_objects:


### PR DESCRIPTION
# SFTP Editor v1.3
This pull requests adds editing capability of utf-8 encoded files with the SFTP client plugin. Utilizing the changes from version 1.2, I have added a tab with a GtkSourceView and added in King Phishers HTML and Jinja autocomplete features for websites into it. You can right click on a target file, and click edit, at this point the second tab will unhide itself, and display the targeted file for editing. As this feature is primarily targeted to edit HTML web server files on the King Phisher server, the SourceView is set to highlight HTML syntax.

## To use and testing
- [x] Enable SFTP Client version 1.3
- [x] select a file in one of the tree-views you wish to edit
- [x] Right click the file, and select `Edit`
  - [x] Test one local file and one remote
- [x] Tabs appear in the SFTP client with the `Editor` automatically select with the target file loaded.
- [x] HTML syntax is highlighted
- [x] Type in the box with all the text.
- [x] Save button becomes `sensitive`
- [x] HTML and Jinja tags are suggested while making changes/adding to the file
- [x] Clicking the save button saves editor contents to the file you are editing
  - [x] Test both a local file, and a remote file
- [x] Status bar at the bottom displays the path of the current file being edited