### PR TITLE
Added: message_plaintext plugin

### DIFF
--- a/client/message_plaintext.py
+++ b/client/message_plaintext.py
@@ -1,4 +1,5 @@
 import king_phisher.client.plugins as plugins
+import king_phisher.client.gui_utilities as gui_utilities
 
 try:
 	from bs4 import BeautifulSoup
@@ -25,7 +26,21 @@ class Plugin(plugins.ClientPlugin):
 		mailer_tab = self.application.main_tabs['mailer']
 		self.signal_connect('message-create', self.signal_message_create, gobject=mailer_tab)
 		if not has_bs4:
-			return False
+			return
+
+		if 'message_padding' in self.application.config['plugins']:
+			proceed = gui_utilities.show_dialog_yes_no(
+				'Warning: You are running a conflicting plugin!',
+				self.application.get_active_window(),
+				'The "message_padding" plugin conflicts with "message_plaintext" in such a way ' \
+				+ 'that will cause the message padding to be revealed in the plaintext version ' \
+				+ 'of the email. It is recommended you disable one of these plugins, or append ' \
+				+ 'additional line breaks in the HTML to conceal it.\n\n' \
+				+ 'Do you wish to continue?'
+			)
+			if not proceed:
+				return
+
 		return True
 
 	def signal_message_create(self, mailer_tab, target, message):

--- a/client/message_plaintext.py
+++ b/client/message_plaintext.py
@@ -25,8 +25,6 @@ class Plugin(plugins.ClientPlugin):
 	def initialize(self):
 		mailer_tab = self.application.main_tabs['mailer']
 		self.signal_connect('message-create', self.signal_message_create, gobject=mailer_tab)
-		if not has_bs4:
-			return
 
 		if 'message_padding' in self.application.config['plugins']:
 			proceed = gui_utilities.show_dialog_yes_no(
@@ -39,12 +37,10 @@ class Plugin(plugins.ClientPlugin):
 				+ 'Do you wish to continue?'
 			)
 			if not proceed:
-				return
-
+				return False
 		return True
 
 	def signal_message_create(self, mailer_tab, target, message):
-
 		for part in message.walk():
 			if not part.get_content_type().startswith('text/html'):
 				continue
@@ -53,7 +49,7 @@ class Plugin(plugins.ClientPlugin):
 		try:
 			soup = BeautifulSoup(html_string, 'html.parser')
 		except NameError:
-			self.logger.error('Unable to generate plaintext message from HTML.')
+			self.logger.error('unable to generate plaintext message from HTML')
 			return False
 
 		plaintext_payload_string = soup.get_text()
@@ -64,5 +60,4 @@ class Plugin(plugins.ClientPlugin):
 			if not part.get_content_type().startswith('text/plain'):
 				continue
 			part.payload_string = plaintext_payload_string
-			self.logger.info('Plaintext modified from html successfully.')
-
+			self.logger.debug('plaintext modified from html successfully')

--- a/client/message_plaintext.py
+++ b/client/message_plaintext.py
@@ -1,0 +1,53 @@
+import king_phisher.client.plugins as plugins
+
+try:
+	from bs4 import BeautifulSoup
+except ImportError:
+	has_bs4 = False
+else:
+	has_bs4 = True
+
+class Plugin(plugins.ClientPlugin):
+	authors = ['Mike Stringer']
+	classifiers = ['Plugin :: Client :: Email :: Message Plaintext']
+	title = 'Message Plaintext'
+	description = """
+	Parse and include a plaintext version of an email based on the HTML version.
+	"""
+	homepage = 'https://github.com/securestate/king-phisher-plugins'
+	options = []
+	req_min_version = '1.10.0'
+	version = '1.0'
+	req_packages = {
+		'bs4' : has_bs4
+	}
+	def initialize(self):
+		mailer_tab = self.application.main_tabs['mailer']
+		self.signal_connect('message-create', self.signal_message_create, gobject=mailer_tab)
+		if not has_bs4:
+			return False
+		return True
+
+	def signal_message_create(self, mailer_tab, target, message):
+
+		for part in message.walk():
+			if not part.get_content_type().startswith('text/html'):
+				continue
+			html_string = part.payload_string
+
+		try:
+			soup = BeautifulSoup(html_string, 'html.parser')
+		except NameError:
+			self.logger.error('Unable to generate plaintext message from HTML.')
+			return False
+
+		plaintext_payload_string = soup.get_text()
+		for a in soup.find_all('a', href=True):
+			if 'mailto:' not in a.string:
+				plaintext_payload_string = plaintext_payload_string.replace(a.string, a['href'])
+		for part in message.walk():
+			if not part.get_content_type().startswith('text/plain'):
+				continue
+			part.payload_string = plaintext_payload_string
+			self.logger.info('Plaintext modified from html successfully.')
+


### PR DESCRIPTION
Fixes [#292](https://github.com/securestate/king-phisher/issues/292)

Another spam-score reducing plugin to match the plaintext version of an html message. 
No options are necessary; however, this plugin causes a potential conflict with [Message Padding](https://github.com/securestate/king-phisher-plugins/blob/dev/client/message_padding.py) due to the Message Padding's inherent purpose of increasing email body length with _garbage text that is hidden using html._

Using these two plugins at the same time causes the plaintext verison of the email to reveal the message padding which may be counter-intuitive to a stealth-based approach. Adding additional `<br />` and `<p> </p>` tags can drop the message padding further down in the message in order to prevent a target from reading the message; however, users must be aware of this and manually account for it. Otherwise, a change will be needed to append **numerous** line breaks to the message_padding plugin.

**Steps to test**
* Simply enable the plugin, send an html-formatted email to yourself, and view message as plaintext.