### PR TITLE
Post fix log fix

### DIFF
--- a/server/postfix_message_info.py
+++ b/server/postfix_message_info.py
@@ -15,6 +15,9 @@ EXAMPLE_CONFIG = """\
   log_file: /var/log/mail.log
 """
 
+#Reduce debuging log lines L96:L98
+#LOG_LINE_BLACKLIST = ['connect from localhost', 'disconnect from localhost', 'daemon started --']
+
 def get_modified_time(path):
 	return os.stat(path).st_mtime
 
@@ -40,7 +43,7 @@ class Plugin(plugins.ServerPlugin):
 	King Phisher clients message status and detail information.
 	"""
 	homepage = 'https://github.com/securestate/king-phisher-plugins'
-	version = '1.0'
+	version = '1.0.1'
 	req_min_version = '1.14.0b1'
 	options = [
 		plugin_opts.OptionString(
@@ -89,13 +92,10 @@ class Plugin(plugins.ServerPlugin):
 		results = {}
 		for line_number, line in enumerate(log_lines, 1):
 			log_id = re.search(r'postfix/[a-z]+\[\d+\]:\s+(?P<log_id>[0-9A-Z]{7,12}):\s+', line)
-			# check blacklist strings to not spam log files
-			blacklist = ['connect from localhost', 'disconnect from localhost', 'daemon started --']
 			if not log_id:
-				for string in blacklist:
-					if string in line:
-						continue
-				self.logger.warning('failed to parse postfix log line: ' + str(line_number))
+			# check blacklist strings to not spam log files
+			#	if not any(string in line for string in LOG_LINE_BLACKLIST):
+			#		self.logger.warning('failed to parse postfix log line: ' + str(line_number))
 				continue
 			log_id = log_id.group('log_id')
 			message_id = re.search(r'message-id=<(?P<mid>[0-9A-Za-z]{12,20})@', line)

--- a/server/postfix_message_info.py
+++ b/server/postfix_message_info.py
@@ -88,12 +88,13 @@ class Plugin(plugins.ServerPlugin):
 	def parse_logs(self, log_lines):
 		results = {}
 		for line_number, line in enumerate(log_lines, 1):
-			# Checks for SMTP connects/disconnects and suppresses them from being logged to prevent log spam.
-			smtp_connections = re.search(r'postfix/[a-z]+\[\d+\]:\s+(?P<connection_status>[a-z]{7,12}):\s+', line)
-			if smtp_connections.connection_status == 'connect' or smtp_connections.connection_status == 'disconnect':
-				continue
 			log_id = re.search(r'postfix/[a-z]+\[\d+\]:\s+(?P<log_id>[0-9A-Z]{7,12}):\s+', line)
+			# check blacklist strings to not spam log files
+			blacklist = ['connect from localhost', 'disconnect from localhost', 'daemon started --']
 			if not log_id:
+				for string in blacklist:
+					if string in line:
+						continue
 				self.logger.warning('failed to parse postfix log line: ' + str(line_number))
 				continue
 			log_id = log_id.group('log_id')


### PR DESCRIPTION
# Post Fix spamming logs bug
The postfix_message_info plugin is currently logging an unnecessary amount of debugging information. As of now the plugin will log anytime some connects or disconnects from the SMTP server and when daemon services are started because the plugin failed to parse the log. This information is not necessary and this PR is looking to suppress the amount of logs produced currently by the plugin.

### Example issue:
Failed to parse: (kp server logs)
```
KingPhisher.Plugins.Server.postfix_message_info.Plugin WARNING  [plugin: postfix_message_info] failed to parse postfix log line: 6546
```
Line 6546: ( postfix logs )
``` 
king-phisher postfix/smtpd[54970]: disconnect from localhost[127.0.0.1] ehlo=2 starttls=1 mail=1 rcpt=1 data=1 quit=1 commands=7
```

### Test Steps:
[ ] Successfully enabled the postfix_message_info plugin.
[ ] Send a message sucesfully
[ ] Verify the plugin did not spam the kp logs with failed to parse warning.
